### PR TITLE
Pawn eval

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -120,6 +120,7 @@ int evaluate(const BOARD * board) {
     BITBOARD pass = passers(my_pawns, their_pawns, colour);
     BITBOARD wk   = weak(my_pawns, colour);
 
+    pawn_value += piece_values[PAWN] * __builtin_popcountll(my_pawns);
     pawn_value -= 20 * __builtin_popcountll(iso);
     for (rank = 1; rank < 7; ++rank) {
       SQUARE erank = colour == WHITE ? rank : 7 - rank;

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -5,17 +5,6 @@
 
 static const int piece_values[] = { 0, 100, 310, 330, 500, 900 };
 
-static const int pawn_bonus[] = {
-   0,  0,  0,  0,  0,  0,  0,  0,
-  50, 50, 50, 50, 50, 50, 50, 50,
-  10, 10, 20, 30, 30, 20, 10, 10,
-   5,  5, 10, 25, 25, 10,  5,  5,
-   0,  0,  0, 20, 20,  0,  0,  0,
-   5, -5,-10,  0,  0,-10, -5,  5,
-   5, 10, 10,-20,-20, 10, 10,  5,
-   0,  0,  0,  0,  0,  0,  0,  0
-};
-
 static const int knight_bonus[] = {
   -50,-40,-30,-30,-30,-30,-40,-50,
   -40,-20,  0,  0,  0,  0,-20,-40,
@@ -84,7 +73,7 @@ static const int king_endgame_bonus[] = {
 
 static const int* bonuses[] = {
   NULL,
-  pawn_bonus,
+  NULL,
   knight_bonus,
   bishop_bonus,
   rook_bonus,


### PR DESCRIPTION
Score of chess2 (pawn_eval) vs chess2 (5727d9cd5a2415c70f645bf5cec20b5a5e088265): 33 - 17 - 11  [0.631] 61
...      chess2 (pawn_eval) playing White: 23 - 0 - 7  [0.883] 30
...      chess2 (pawn_eval) playing Black: 10 - 17 - 4  [0.387] 31
...      White vs Black: 40 - 10 - 11  [0.746] 61
Elo difference: 93.3 +/- 82.9, LOS: 98.8 %, DrawRatio: 18.0 %
SPRT: llr -3.18 (-107.9%), lbound -2.94, ubound 2.94 - H0 was accepted
Finished match