### PR TITLE
increased minor piece eval

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -3,7 +3,7 @@
 #include "evaluate.h"
 #include "pawns.h"
 
-static const int piece_values[] = { 0, 100, 310, 330, 500, 900 };
+static const int piece_values[] = { 0, 100, 350, 370, 500, 900 };
 
 static const int knight_bonus[] = {
   -50,-40,-30,-30,-30,-30,-40,-50,


### PR DESCRIPTION
Score of chess2 (increased_minor) vs chess2 (f705e3dc28029bcf5bfde461c1042ae1b40b157a): 70 - 24 - 34  [0.680] 128
...      chess2 (increased_minor) playing White: 44 - 8 - 12  [0.781] 64
...      chess2 (increased_minor) playing Black: 26 - 16 - 22  [0.578] 64
...      White vs Black: 60 - 34 - 34  [0.602] 128
Elo difference: 130.7 +/- 54.3, LOS: 100.0 %, DrawRatio: 26.6 %
SPRT: llr -2.66 (-90.5%), lbound -2.94, ubound 2.94