### PR TITLE
Psqt order

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -82,6 +82,19 @@ static const int* bonuses[] = {
   king_endgame_bonus
 };
 
+int psqt_value(PIECE piece, COLOUR colour, SQUARE from, SQUARE to) {
+  if (piece < KNIGHT || piece > QUEEN) {
+    return 0;
+  }
+
+  if (colour == WHITE) {
+    from = ((63 - from) & ~0x7) | (from & 0x7);
+    to   = ((63 - to) & ~0x7) | (to & 0x7);
+  }
+
+  return bonuses[piece][to] - bonuses[piece][from];
+}
+
 int evaluate(const BOARD * board) {
   int value = 0;
   int dir[] = {1, -1};

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -4,5 +4,6 @@
 #include "board.h"
 
 int evaluate(const BOARD * board);
+int psqt_value(PIECE piece, COLOUR colour, SQUARE from, SQUARE to);
 
 #endif /* ifndef _EVALUATE_H_ */

--- a/src/movelist.c
+++ b/src/movelist.c
@@ -7,6 +7,8 @@
 #include "moveexec.h"
 #include "chess.h"
 #include "see.h"
+#include "evaluate.h"
+
 
 #define MAX_MOVES 2048
 
@@ -81,8 +83,13 @@ static void heuristic_weights(BOARD* board, const MOVE * pv, int depth, const KI
       ptr->value = 10090;
     } else if (killer != NULL && is_killer(killer, depth, 2, ptr)) {
       ptr->value = 10080;
-    } else {
+    } else if (ptr->special & (CAPTURED_MOVE_MASK | EN_PASSANT_CAPTURE_MOVE_MASK)) {
       ptr->value = see(board, ptr) + 1000;
+    } else {
+      ptr->value = psqt_value((ptr->special & PIECE_MOVE_MASK) >> PIECE_MOVE_SHIFT,
+          board->next,
+          (SQUARE)__builtin_ctzll(ptr->from),
+          (SQUARE)__builtin_ctzll(ptr->to)) + 500;
     }
   }
 }


### PR DESCRIPTION
```
Comparing times
x main_bench_results.txt
+ psqt_order_bench_results.txt
+--------------------------------------------------+
|      + +                           x             |
|      + +                           x             |
|     ++ +                           xx            |
|    +++ +                           xx xxxx       |
|   ++++++  +                        xx xxxx x x   |
|+ +++++++++++                     x xx xxxxxx x  x|
|    |_A__|                          |__MA__|      |
+--------------------------------------------------+
    N           Min           Max        Median           Avg        Stddev
x  30          9859         11534         10456     10484.533      409.6731
+  30          6000          7369          6710     6728.8667     309.82016
Difference at 95.0% confidence
        -3755.67 +/- 187.74
        -35.821% +/- 1.79064%
        (Student's t, pooled s = 363.195)
Comparing nps
x main_bench_results.txt
+ psqt_order_bench_results.txt
+--------------------------------------------------+
|                    x   +                         |
|                    x   +                         |
|           x       xx   +                         |
|        x  xxxx   *xx   +  + +++  ++   +          |
|x   xx xx xxxx*xxx**x +x++ + ++++++++  + +       +|
|        |_____A_____||_______A_______|            |
+--------------------------------------------------+
    N           Min           Max        Median           Avg        Stddev
x  30        910140       1064769       1003977     1002688.5     38326.866
+  30       1005099       1234430       1103820     1102989.2      51148.71
Difference at 95.0% confidence
        100301 +/- 23361.8
        10.0032% +/- 2.32992%
        (Student's t, pooled s = 45194.8)
```