### PR TITLE
Fixes #20. Fix overruning killer

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -332,7 +332,7 @@ int iterative_deepening(BOARD * board, const SEARCH_LIMIT * search_limit) {
           break;
       }
 
-      max_depth = 1000;
+      max_depth = MAX_PLYS; /* we would overrun our stores otherwise */
       movetime = (time + MOVES_TO_GO * inc) / MOVES_TO_GO;
       movetime = movetime > time / 2 ? time / 2 : movetime;
 


### PR DESCRIPTION
This happenes in a situ where a new depth takes very little time.

When running search with time limit, and a single depth takes very little time, iterative deepening kept going beyond the sizes of our stores.